### PR TITLE
Agregar API básica de clientes

### DIFF
--- a/backend/clientes/urls.py
+++ b/backend/clientes/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('crear_cliente/', views.crear_cliente, name='crear_cliente'),
+    path('listar_clientes/', views.listar_clientes, name='listar_clientes'),
+    path('eliminar_clientes/', views.eliminar_clientes, name='eliminar_clientes'),
+]

--- a/backend/clientes/views.py
+++ b/backend/clientes/views.py
@@ -1,3 +1,20 @@
-from django.shortcuts import render
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
 
-# Create your views here.
+
+@api_view(["POST"])
+def crear_cliente(request):
+    """Crea un cliente de ejemplo."""
+    return Response("cliente creado")
+
+
+@api_view(["GET"])
+def listar_clientes(request):
+    """Lista clientes de ejemplo."""
+    return Response("Lista de clientes")
+
+
+@api_view(["DELETE"])
+def eliminar_clientes(request):
+    """Elimina un cliente de ejemplo."""
+    return Response("Cliente eliminado")

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
     'clientes',
 ]
 

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('', include('clientes.urls')),
 ]


### PR DESCRIPTION
## Resumen
- Añade `rest_framework` a la configuración del proyecto.
- Implementa vistas simples para crear, listar y eliminar clientes.
- Crea rutas dedicadas y enlaza el módulo de clientes en las URLs del proyecto.

## Pruebas
- `python backend/manage.py test` *(falló: ModuleNotFoundError: No module named 'django')*
- `pip install djangorestframework` *(falló: Could not find a version that satisfies the requirement djangorestframework)*

------
https://chatgpt.com/codex/tasks/task_e_6893f362e4488322af2f7cded5b38306