### PR TITLE
Agregar gestión de clientes y vistas Angular con API centralizada

### DIFF
--- a/backend/clientes/migrations/0001_initial.py
+++ b/backend/clientes/migrations/0001_initial.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name='Cliente',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('nombre', models.CharField(max_length=100)),
+                ('email', models.EmailField(max_length=254, unique=True)),
+            ],
+        ),
+    ]

--- a/backend/clientes/models.py
+++ b/backend/clientes/models.py
@@ -1,3 +1,9 @@
 from django.db import models
 
-# Create your models here.
+
+class Cliente(models.Model):
+    nombre = models.CharField(max_length=100)
+    email = models.EmailField(unique=True)
+
+    def __str__(self) -> str:
+        return self.nombre

--- a/backend/clientes/serializers.py
+++ b/backend/clientes/serializers.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+from .models import Cliente
+
+
+class ClienteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Cliente
+        fields = ['id', 'nombre', 'email']

--- a/backend/clientes/urls.py
+++ b/backend/clientes/urls.py
@@ -1,8 +1,8 @@
 from django.urls import path
-from . import views
+from .views import ClienteDetailView, ClienteListCreateView
+
 
 urlpatterns = [
-    path('crear_cliente/', views.crear_cliente, name='crear_cliente'),
-    path('listar_clientes/', views.listar_clientes, name='listar_clientes'),
-    path('eliminar_clientes/', views.eliminar_clientes, name='eliminar_clientes'),
+    path('clientes/', ClienteListCreateView.as_view(), name='cliente-list-create'),
+    path('clientes/<int:pk>/', ClienteDetailView.as_view(), name='cliente-detail'),
 ]

--- a/backend/clientes/views.py
+++ b/backend/clientes/views.py
@@ -1,20 +1,13 @@
-from rest_framework.decorators import api_view
-from rest_framework.response import Response
+from rest_framework import generics
+from .models import Cliente
+from .serializers import ClienteSerializer
 
 
-@api_view(["POST"])
-def crear_cliente(request):
-    """Crea un cliente de ejemplo."""
-    return Response("cliente creado")
+class ClienteListCreateView(generics.ListCreateAPIView):
+    queryset = Cliente.objects.all()
+    serializer_class = ClienteSerializer
 
 
-@api_view(["GET"])
-def listar_clientes(request):
-    """Lista clientes de ejemplo."""
-    return Response("Lista de clientes")
-
-
-@api_view(["DELETE"])
-def eliminar_clientes(request):
-    """Elimina un cliente de ejemplo."""
-    return Response("Cliente eliminado")
+class ClienteDetailView(generics.RetrieveUpdateDestroyAPIView):
+    queryset = Cliente.objects.all()
+    serializer_class = ClienteSerializer

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,1 +1,2 @@
 Django
+djangorestframework

--- a/frontend/gestion-frontend/src/app/api.config.ts
+++ b/frontend/gestion-frontend/src/app/api.config.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = 'http://localhost:8000/';

--- a/frontend/gestion-frontend/src/app/app.config.ts
+++ b/frontend/gestion-frontend/src/app/app.config.ts
@@ -1,4 +1,5 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZonelessChangeDetection } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
@@ -7,6 +8,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZonelessChangeDetection(),
-    provideRouter(routes)
+    provideRouter(routes),
+    provideHttpClient()
   ]
 };

--- a/frontend/gestion-frontend/src/app/app.routes.ts
+++ b/frontend/gestion-frontend/src/app/app.routes.ts
@@ -1,3 +1,7 @@
 import { Routes } from '@angular/router';
+import { ClientesComponent } from './clientes/clientes.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: 'clientes', component: ClientesComponent },
+  { path: '', redirectTo: 'clientes', pathMatch: 'full' }
+];

--- a/frontend/gestion-frontend/src/app/clientes/clientes.component.html
+++ b/frontend/gestion-frontend/src/app/clientes/clientes.component.html
@@ -1,0 +1,9 @@
+<form [formGroup]="form" (ngSubmit)="crearCliente()">
+  <input formControlName="nombre" placeholder="Nombre" />
+  <input formControlName="email" placeholder="Email" />
+  <button type="submit">Crear</button>
+</form>
+
+<ul>
+  <li *ngFor="let c of clientes">{{ c.nombre }} - {{ c.email }}</li>
+</ul>

--- a/frontend/gestion-frontend/src/app/clientes/clientes.component.scss
+++ b/frontend/gestion-frontend/src/app/clientes/clientes.component.scss
@@ -1,0 +1,1 @@
+/* Estilos para el componente de clientes */

--- a/frontend/gestion-frontend/src/app/clientes/clientes.component.ts
+++ b/frontend/gestion-frontend/src/app/clientes/clientes.component.ts
@@ -1,0 +1,40 @@
+import { Component, OnInit } from '@angular/core';
+import { NgFor } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { ApiService } from '../services/api.service';
+
+@Component({
+  selector: 'app-clientes',
+  standalone: true,
+  imports: [NgFor, ReactiveFormsModule],
+  templateUrl: './clientes.component.html',
+  styleUrls: ['./clientes.component.scss']
+})
+export class ClientesComponent implements OnInit {
+  clientes: any[] = [];
+  form: FormGroup;
+
+  constructor(private api: ApiService, private fb: FormBuilder) {
+    this.form = this.fb.group({
+      nombre: [''],
+      email: ['']
+    });
+  }
+
+  ngOnInit(): void {
+    this.cargarClientes();
+  }
+
+  cargarClientes(): void {
+    this.api.getClientes().subscribe(data => (this.clientes = data));
+  }
+
+  crearCliente(): void {
+    if (this.form.valid) {
+      this.api.createCliente(this.form.value).subscribe(() => {
+        this.form.reset();
+        this.cargarClientes();
+      });
+    }
+  }
+}

--- a/frontend/gestion-frontend/src/app/services/api.service.ts
+++ b/frontend/gestion-frontend/src/app/services/api.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { API_BASE_URL } from '../api.config';
+
+@Injectable({ providedIn: 'root' })
+export class ApiService {
+  private baseUrl = API_BASE_URL;
+
+  constructor(private http: HttpClient) {}
+
+  getClientes(): Observable<any> {
+    return this.http.get(`${this.baseUrl}clientes/`);
+  }
+
+  createCliente(cliente: any): Observable<any> {
+    return this.http.post(`${this.baseUrl}clientes/`, cliente);
+  }
+}


### PR DESCRIPTION
## Resumen
- Definido modelo `Cliente` y API REST con vistas genéricas y serializador en Django.
- Incorporada URL base centralizada y servicio HTTP en Angular para consumir el API.
- Añadido componente Angular para listar y crear clientes desde la aplicación.

## Pruebas
- `pip install -r requirements.txt` *(falló: Could not connect to proxy)*
- `python manage.py test` *(falló: No module named 'rest_framework')*
- `npm test --prefix frontend/gestion-frontend -- --watch=false` *(falló: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6897a16abe048322aeb4fe9717f1da4c